### PR TITLE
Adding mechanism to catch up to missing slot entries

### DIFF
--- a/examples/http-paxos/commands.rs
+++ b/examples/http-paxos/commands.rs
@@ -15,6 +15,7 @@ enum Command {
     Reject(NodeId, #[serde(with = "BallotDef")] Ballot, #[serde(with = "BallotDef")] Ballot),
     Accepted(NodeId, #[serde(with = "BallotDef")] Ballot, Vec<Slot>),
     Resolution(#[serde(with = "BallotDef")] Ballot, Vec<(Slot, Bytes)>),
+    Catchup(NodeId, Vec<Slot>),
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
@@ -60,6 +61,7 @@ pub fn invoke<C: Commander>(replica: &mut C, command: Bytes) {
         Command::Reject(node, proposed, preempted) => replica.reject(node, proposed, preempted),
         Command::Accepted(node, bal, slots) => replica.accepted(node, bal, slots),
         Command::Resolution(bal, vals) => replica.resolution(bal, vals),
+        Command::Catchup(node, slots) => replica.catchup(node, slots),
     };
 }
 
@@ -130,5 +132,9 @@ impl Commander for PaxosCommander {
 
     fn resolution(&mut self, bal: Ballot, values: Vec<(Slot, Bytes)>) {
         self.send(Command::Resolution(bal, values));
+    }
+
+    fn catchup(&mut self, node: NodeId, slots: Vec<Slot>) {
+        self.send(Command::Catchup(node, slots));
     }
 }

--- a/examples/http-paxos/main.rs
+++ b/examples/http-paxos/main.rs
@@ -18,7 +18,7 @@ use hyper::{
     service::{make_service_fn, service_fn},
     Server,
 };
-use paxos::{Configuration, NodeId, Replica, Liveness};
+use paxos::{Configuration, Liveness, NodeId, Replica};
 use std::{env::args, net::SocketAddr, process::exit};
 
 fn config() -> paxos::Configuration {

--- a/examples/http-paxos/service.rs
+++ b/examples/http-paxos/service.rs
@@ -61,7 +61,8 @@ impl Handler {
                 let id = random::<u64>();
                 let receiver = {
                     let mut replica = self.replica.lock().await;
-                    let receiver = replica.inner_mut().sender_mut().state_machine().register_set(id);
+                    let receiver =
+                        replica.inner_mut().sender_mut().state_machine().register_set(id);
                     replica.proposal(KvCommand::Set { request_id: id, key, value }.into());
                     receiver
                 };
@@ -79,7 +80,8 @@ impl Handler {
                 let id = random::<u64>();
                 let receiver = {
                     let mut replica = self.replica.lock().await;
-                    let receiver = replica.inner_mut().sender_mut().state_machine().register_get(id);
+                    let receiver =
+                        replica.inner_mut().sender_mut().state_machine().register_get(id);
                     replica.proposal(KvCommand::Get { request_id: id, key }.into());
                     receiver
                 };

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -55,6 +55,10 @@ pub trait Commander {
     /// NOTE: Resolutions may arrive out-of-order. No guarantees are made on
     /// slot order.
     fn resolution(&mut self, bal: Ballot, values: Vec<(Slot, Bytes)>);
+
+    /// Request sent to a distinguished learner to catch up to latest slot
+    /// values.
+    fn catchup(&mut self, node: NodeId, slots: Vec<Slot>);
 }
 
 // TODO: is it possible to avoid sending Bytes back to replicas that know of the
@@ -70,6 +74,7 @@ pub enum Command {
     Reject(NodeId, Ballot, Ballot),
     Accepted(NodeId, Ballot, Vec<Slot>),
     Resolution(Ballot, Vec<(Slot, Bytes)>),
+    Catchup(NodeId, Vec<Slot>),
 }
 
 #[cfg(test)]
@@ -103,5 +108,9 @@ where
 
     fn resolution(&mut self, bal: Ballot, values: Vec<(Slot, Bytes)>) {
         self.extend(Some(Command::Resolution(bal, values)));
+    }
+
+    fn catchup(&mut self, node: NodeId, slots: Vec<Slot>) {
+        self.extend(Some(Command::Catchup(node, slots)));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,8 @@ use std::cmp;
 
 pub use commands::{Commander, Sender};
 pub use config::{Configuration, PeerIntoIter, PeerIter};
-pub use replica::Replica;
 pub use liveness::Liveness;
+pub use replica::Replica;
 pub use statemachine::ReplicatedState;
 
 /// Increasing sequence number of Paxos instances.

--- a/src/liveness.rs
+++ b/src/liveness.rs
@@ -57,6 +57,10 @@ impl<R: Commander + LeaderElection> Commander for Liveness<R> {
         self.leader_election.bump();
         self.inner.resolution(bal, values);
     }
+
+    fn catchup(&mut self, node: NodeId, slots: Vec<Slot>) {
+        self.inner.catchup(node, slots);
+    }
 }
 
 impl<R: Commander + LeaderElection> Tick for Liveness<R> {


### PR DESCRIPTION
The catch up is triggered when the open range is detected to be less
than a received resolution from the leader.

Fixes #76