### PR TITLE
New trait for Replicas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +143,9 @@ name = "futures-task"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "futures-util"
@@ -139,9 +154,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project",
  "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
 ]
 
 [[package]]
@@ -371,12 +390,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+
+[[package]]
 name = "paxos"
 version = "0.1.0"
 dependencies = [
  "bincode",
  "bytes",
  "env_logger",
+ "futures-util",
  "hyper",
  "lazy_static",
  "log",
@@ -422,6 +448,18 @@ name = "ppv-lite86"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ hyper = "0.13"
 tokio = { version = "0.2", features = ["rt-core","macros","sync"] }
 env_logger = "0.7.1"
 rand = "0.7.3"
+futures-util = "0.3"

--- a/examples/http-paxos/main.rs
+++ b/examples/http-paxos/main.rs
@@ -18,7 +18,7 @@ use hyper::{
     service::{make_service_fn, service_fn},
     Server,
 };
-use paxos::{Configuration, Liveness, NodeId, Replica};
+use paxos::{Configuration, Liveness, NodeId, NodeMetadata, Replica};
 use std::{env::args, net::SocketAddr, process::exit};
 
 fn config() -> paxos::Configuration {
@@ -45,9 +45,9 @@ fn config() -> paxos::Configuration {
 
     Configuration::new(
         node_id,
-        (0u32..3)
-            .filter(|n| *n != node_id)
-            .map(|n| (n as NodeId, format!("127.0.0.1:808{}", n).parse().unwrap())),
+        (0u32..3).filter(|n| *n != node_id).map(|n| {
+            (n as NodeId, NodeMetadata(format!("http://127.0.0.1:808{}/paxos", n).into()))
+        }),
     )
 }
 

--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -50,17 +50,14 @@ impl Acceptor {
     /// Resolves a value within the learner state
     pub fn resolve(&mut self, bal: Ballot, val: Bytes) {
         // ignore if the acceptor is already resolved
-        match self.state {
-            AcceptorState::Resolved { accepted, ref value } => {
-                if accepted != bal || val != value {
-                    warn!(
-                        "Attempt to resolve to a different ballot or value. Accepted=<{:?},{:?}>, Attempted=<{:?},{:?}>",
-                        accepted, value, bal, val
-                    );
-                }
-                return;
+        if let AcceptorState::Resolved { accepted, ref value } = self.state {
+            if accepted != bal || val != value {
+                warn!(
+                    "Attempt to resolve to a different ballot or value. Accepted=<{:?},{:?}>, Attempted=<{:?},{:?}>",
+                    accepted, value, bal, val
+                );
             }
-            _ => {}
+            return;
         }
 
         self.state = AcceptorState::Resolved { accepted: bal, value: val };

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,4 +1,4 @@
-use crate::{Ballot, NodeId, ReplicatedState, Slot};
+use crate::{Ballot, NodeId, NodeMetadata, Slot};
 use bytes::Bytes;
 
 #[cfg(test)]
@@ -6,20 +6,14 @@ use std::iter::Extend;
 
 /// Sends commands to other replicas in addition to applying
 /// resolved commands at the current replica
-pub trait Sender {
+pub trait Transport {
     /// Commander type used to send messages to other instances
     type Commander: Commander;
 
-    /// The state machine used by this replica
-    type StateMachine: ReplicatedState;
-
     /// Send a message to a single node
-    fn send_to<F>(&mut self, node: NodeId, command: F)
+    fn send_to<F>(&mut self, node: NodeId, node_metadata: &NodeMetadata, command: F)
     where
         F: FnOnce(&mut Self::Commander) -> ();
-
-    /// Resolves the state machine to apply values.
-    fn state_machine(&mut self) -> &mut Self::StateMachine;
 }
 
 /// Receiver of Paxos commands.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use crate::NodeId;
 use bytes::Bytes;
-use std::{collections::HashMap, fmt};
+use std::{collections::HashMap, fmt, ops::Index};
 
 #[derive(Default, Clone, Debug, Eq, PartialEq)]
 /// Opaque, applicaiton specific metadata for nodes in the system
@@ -58,6 +58,13 @@ impl Configuration {
     }
 }
 
+impl Index<NodeId> for Configuration {
+    type Output = NodeMetadata;
+    fn index(&self, node: NodeId) -> &NodeMetadata {
+        &self.peers[&node]
+    }
+}
+
 impl fmt::Debug for Configuration {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let (p1_q, p2_q) = self.quorum_size();
@@ -109,13 +116,15 @@ impl QuorumSet {
 
     #[inline]
     fn search(&self, n: NodeId) -> Result<usize, usize> {
-        self.values.iter().enumerate().find_map(|(i, elem)| {
-            match elem {
+        self.values
+            .iter()
+            .enumerate()
+            .find_map(|(i, elem)| match elem {
                 Some(nd) if *nd == n => Some(Ok(i)),
                 None => Some(Err(i)),
                 _ => None,
-            }
-        }).unwrap_or_else(|| Err(self.values.len()-1))
+            })
+            .unwrap_or_else(|| Err(self.values.len() - 1))
     }
 
     /// Inserts a node into the set

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,13 @@
 //! ```rust,no_run
 //! # extern crate paxos;
 //! # use paxos::{Replica, Configuration};
+//! # use bytes::Bytes;
 //!
 //! # fn main() {
 //! let config = Configuration::new(
 //!     0u32,
-//!     vec![(1, "127.0.0.1:4001".parse().unwrap()),
-//!          (2, "127.0.0.1:4002".parse().unwrap())].into_iter());
+//!     vec![(1, Bytes::from("127.0.0.1:4001").into()),
+//!          (2, Bytes::from("127.0.0.1:4002").into())].into_iter());
 //!
 //! unimplemented!("TODO: finish example");
 //! # }
@@ -41,7 +42,7 @@ mod window;
 use std::cmp;
 
 pub use commands::{Commander, Sender};
-pub use config::{Configuration, PeerIntoIter, PeerIter};
+pub use config::{Configuration, NodeMetadata};
 pub use liveness::Liveness;
 pub use replica::Replica;
 pub use statemachine::ReplicatedState;

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -1,4 +1,4 @@
-use crate::Slot;
+use crate::{Ballot, Commander, DecisionSet, NodeId, Replica, Slot};
 use bytes::Bytes;
 
 /// A state machine that executes sequentially applied commands.
@@ -9,4 +9,213 @@ pub trait ReplicatedState {
     /// such that there is no guarantee that _slot-1_ has been
     /// applied before _slot_.
     fn execute(&mut self, slot: Slot, command: Bytes);
+}
+
+/// Replica that executes commands within a state machine
+pub struct StateMachineReplica<R: Replica, S: ReplicatedState> {
+    inner: R,
+    state_machine: S,
+    next_execution_slot: Slot,
+}
+
+impl<R: Replica, S: ReplicatedState> StateMachineReplica<R, S> {
+    pub(crate) fn new(replica: R, state_machine: S) -> StateMachineReplica<R, S> {
+        StateMachineReplica { inner: replica, state_machine, next_execution_slot: 0 }
+    }
+
+    fn try_execute_slots(&mut self) {
+        let mut next_slot = self.next_execution_slot;
+        let decided = self.decisions().range(self.next_execution_slot..).collect::<Vec<_>>();
+        for (slot, decision) in decided {
+            if !decision.is_empty() {
+                self.state_machine.execute(slot, decision)
+            }
+            next_slot = slot + 1;
+        }
+        self.next_execution_slot = next_slot;
+    }
+}
+
+impl<R: Replica, S: ReplicatedState> Commander for StateMachineReplica<R, S> {
+    fn proposal(&mut self, val: Bytes) {
+        self.inner.proposal(val);
+    }
+
+    fn prepare(&mut self, bal: Ballot) {
+        self.inner.prepare(bal);
+    }
+
+    fn promise(&mut self, node: NodeId, bal: Ballot, accepted: Vec<(Slot, Ballot, Bytes)>) {
+        self.inner.promise(node, bal, accepted);
+    }
+
+    fn accept(&mut self, bal: Ballot, slot_values: Vec<(Slot, Bytes)>) {
+        self.inner.accept(bal, slot_values);
+    }
+
+    fn reject(&mut self, node: NodeId, proposed: Ballot, preempted: Ballot) {
+        self.inner.reject(node, proposed, preempted);
+    }
+
+    fn accepted(&mut self, node: NodeId, bal: Ballot, slots: Vec<Slot>) {
+        self.inner.accepted(node, bal, slots);
+        self.try_execute_slots();
+    }
+
+    fn resolution(&mut self, bal: Ballot, values: Vec<(Slot, Bytes)>) {
+        self.inner.resolution(bal, values);
+        self.try_execute_slots();
+    }
+
+    fn catchup(&mut self, node: NodeId, slots: Vec<Slot>) {
+        self.inner.catchup(node, slots);
+    }
+}
+
+impl<R: Replica, S: ReplicatedState> Replica for StateMachineReplica<R, S> {
+    fn propose_leadership(&mut self) {
+        self.inner.propose_leadership();
+    }
+
+    fn is_leader(&self) -> bool {
+        self.inner.is_leader()
+    }
+
+    fn decisions(&self) -> DecisionSet {
+        self.inner.decisions()
+    }
+
+    fn tick(&mut self) {
+        self.inner.tick();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        commands::{Command, Commander},
+        window::{DecisionSet, SlotWindow},
+    };
+
+    #[test]
+    fn resolve_executes_decisions() {
+        let mut inner_replica = FakeReplica(SlotWindow::new(2));
+        {
+            inner_replica.0.next_slot().acceptor().resolve(Ballot(1, 1), "0".into());
+        }
+        {
+            inner_replica.0.next_slot().acceptor().resolve(Ballot(1, 1), "1".into());
+        }
+        {
+            inner_replica
+                .0
+                .slot_mut(3)
+                .unwrap_empty()
+                .fill()
+                .acceptor()
+                .resolve(Ballot(2, 2), "2".into());
+        }
+
+        let mut replica = StateMachineReplica::new(inner_replica, VecStateMachine::default());
+        replica.resolution(Ballot(2, 2), vec![]);
+        assert_eq!(vec![(0u64, Bytes::from("0")), (1, Bytes::from("1"))], replica.state_machine.0);
+        replica.state_machine.0.clear();
+
+        // does not happen again
+        replica.resolution(Ballot(2, 2), vec![]);
+        assert!(replica.state_machine.0.is_empty());
+
+        // fill hole in slot 2, freeing 3
+        {
+            replica
+                .inner
+                .0
+                .slot_mut(2)
+                .unwrap_open()
+                .acceptor()
+                .resolve(Ballot(1, 1), Bytes::default());
+        }
+
+        replica.resolution(Ballot(2, 2), vec![]);
+        assert_eq!(vec![(3u64, Bytes::from("2"))], replica.state_machine.0);
+    }
+
+    #[test]
+    fn accepted_executes_decisions() {
+        let mut inner_replica = FakeReplica(SlotWindow::new(2));
+        {
+            inner_replica.0.next_slot().acceptor().resolve(Ballot(1, 1), "0".into());
+        }
+        {
+            inner_replica.0.next_slot().acceptor().resolve(Ballot(1, 1), "1".into());
+        }
+        {
+            inner_replica
+                .0
+                .slot_mut(3)
+                .unwrap_empty()
+                .fill()
+                .acceptor()
+                .resolve(Ballot(2, 2), "2".into());
+        }
+
+        let mut replica = StateMachineReplica::new(inner_replica, VecStateMachine::default());
+        replica.accepted(0, Ballot(2, 2), vec![]);
+        assert_eq!(vec![(0u64, Bytes::from("0")), (1, Bytes::from("1"))], replica.state_machine.0);
+        replica.state_machine.0.clear();
+
+        // does not happen again
+        replica.accepted(1, Ballot(2, 2), vec![]);
+        assert!(replica.state_machine.0.is_empty());
+
+        // fill hole in slot 2, freeing 3
+        {
+            replica
+                .inner
+                .0
+                .slot_mut(2)
+                .unwrap_open()
+                .acceptor()
+                .resolve(Ballot(1, 1), Bytes::default());
+        }
+
+        replica.accepted(2, Ballot(2, 2), vec![]);
+        assert_eq!(vec![(3u64, Bytes::from("2"))], replica.state_machine.0);
+    }
+
+    #[derive(Default)]
+    struct VecStateMachine(Vec<(Slot, Bytes)>);
+    impl ReplicatedState for VecStateMachine {
+        fn execute(&mut self, slot: Slot, val: Bytes) {
+            self.0.push((slot, val))
+        }
+    }
+
+    struct FakeReplica(SlotWindow);
+    impl Extend<Command> for FakeReplica {
+        fn extend<T>(&mut self, _iter: T)
+        where
+            T: IntoIterator<Item = Command>,
+        {
+        }
+    }
+
+    impl Replica for FakeReplica {
+        fn propose_leadership(&mut self) {
+            unimplemented!();
+        }
+
+        fn is_leader(&self) -> bool {
+            unimplemented!()
+        }
+
+        fn tick(&mut self) {
+            unimplemented!()
+        }
+
+        fn decisions(&self) -> DecisionSet {
+            self.0.decisions()
+        }
+    }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -75,7 +75,7 @@ impl SlotWindow {
 
     /// Opens the next slot
     pub fn next_slot(&mut self) -> OpenSlotMutRef {
-        if self.open.last().is_some() && !self.open.last().unwrap().highest_value().is_some() {
+        if self.open.last().is_some() && self.open.last().unwrap().highest_value().is_none() {
             return OpenSlotMutRef { i: self.open.len() - 1, window: self };
         }
 
@@ -112,7 +112,7 @@ impl SlotWindow {
             self.open_min_slot += (i as u64) + 1;
             let resolutions = self.open.drain(0..=i).map(|open_slot| {
                 let (bal, val) = open_slot.resolution().unwrap();
-                ResolvedSlot(bal, val.clone())
+                ResolvedSlot(bal, val)
             });
             self.decided.extend(resolutions);
             self.fill_open_slots(self.open_min_slot);


### PR DESCRIPTION
* Introduces the `Replica` trait that is the basis for common functionality
* `Liveness` and `StateMachine` are optional `Replica` implementations that layer on functionality. 
* Provides the basis for additional functionality without changing the core algorithm
* Rewrite the config module to have opaque application-specific metadata

Fixes #86