### PR TITLE
Introduce Receiver trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 
 [dependencies]
 log = "0.4"
-bytes = "0.5"
+serde = { version = "1.0", features = ["derive"] }
+bytes = { version = "0.5", features = ["serde"] }
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/examples/http-paxos/commands.rs
+++ b/examples/http-paxos/commands.rs
@@ -1,85 +1,20 @@
 use bincode::{deserialize, serialize};
 use bytes::Bytes;
 use hyper::{client::HttpConnector, Body, Client, Request};
-use paxos::{Ballot, Commander, NodeId, NodeMetadata, Slot, Transport};
-use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, str};
-
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
-enum Command {
-    Proposal(Bytes),
-    Prepare(#[serde(with = "BallotDef")] Ballot),
-    Promise(NodeId, #[serde(with = "BallotDef")] Ballot, Vec<SlotValueTuple>),
-    Accept(#[serde(with = "BallotDef")] Ballot, Vec<(Slot, Bytes)>),
-    Reject(NodeId, #[serde(with = "BallotDef")] Ballot, #[serde(with = "BallotDef")] Ballot),
-    Accepted(NodeId, #[serde(with = "BallotDef")] Ballot, Vec<Slot>),
-    Resolution(#[serde(with = "BallotDef")] Ballot, Vec<(Slot, Bytes)>),
-    Catchup(NodeId, Vec<Slot>),
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
-struct SlotValueTuple(Slot, #[serde(with = "BallotDef")] Ballot, Bytes);
-
-#[derive(Serialize, Deserialize)]
-#[serde(remote = "Ballot")]
-struct BallotDef(pub u32, pub u32);
+use paxos::{Command, NodeId, NodeMetadata, Receiver, Transport};
 
 pub struct HttpTransport {
-    peers: HashMap<NodeId, PaxosCommander>,
     client: Client<HttpConnector, Body>,
 }
 
 impl Default for HttpTransport {
     fn default() -> HttpTransport {
-        HttpTransport { client: Client::new(), peers: HashMap::new() }
+        HttpTransport { client: Client::new() }
     }
 }
 
 impl Transport for HttpTransport {
-    type Commander = PaxosCommander;
-
-    fn send_to<F>(&mut self, node: NodeId, meta: &NodeMetadata, command: F)
-    where
-        F: FnOnce(&mut Self::Commander) -> (),
-    {
-        if !self.peers.contains_key(&node) {
-            self.peers.insert(
-                node,
-                PaxosCommander(self.client.clone(), String::from_utf8(meta.0.to_vec()).unwrap()),
-            );
-        }
-
-        let commander = self.peers.get_mut(&node).unwrap();
-        command(commander);
-    }
-}
-
-pub fn invoke<C: Commander>(replica: &mut C, command: Bytes) {
-    let cmd = match deserialize(&command) {
-        Ok(cmd) => cmd,
-        Err(_) => return,
-    };
-
-    match cmd {
-        Command::Proposal(val) => replica.proposal(val),
-        Command::Prepare(bal) => replica.prepare(bal),
-        Command::Promise(node, bal, accepted) => replica.promise(
-            node,
-            bal,
-            accepted.into_iter().map(|SlotValueTuple(slot, bal, val)| (slot, bal, val)).collect(),
-        ),
-        Command::Accept(bal, vals) => replica.accept(bal, vals),
-        Command::Reject(node, proposed, preempted) => replica.reject(node, proposed, preempted),
-        Command::Accepted(node, bal, slots) => replica.accepted(node, bal, slots),
-        Command::Resolution(bal, vals) => replica.resolution(bal, vals),
-        Command::Catchup(node, slots) => replica.catchup(node, slots),
-    };
-}
-
-pub struct PaxosCommander(Client<HttpConnector, Body>, String);
-
-impl PaxosCommander {
-    fn send(&mut self, cmd: Command) {
+    fn send(&mut self, _node: NodeId, meta: &NodeMetadata, cmd: Command) {
         let bytes = match serialize(&cmd) {
             Ok(bytes) => bytes,
             Err(e) => {
@@ -88,45 +23,16 @@ impl PaxosCommander {
             }
         };
 
-        let request = Request::builder().method("POST").uri(&self.1).body(bytes.into()).unwrap();
-        tokio::spawn(self.0.request(request));
+        let request =
+            Request::builder().method("POST").uri(meta.0.as_ref()).body(bytes.into()).unwrap();
+        tokio::spawn(self.client.request(request));
     }
 }
 
-impl Commander for PaxosCommander {
-    fn proposal(&mut self, val: Bytes) {
-        self.send(Command::Proposal(val));
-    }
-
-    fn prepare(&mut self, bal: Ballot) {
-        self.send(Command::Prepare(bal));
-    }
-
-    fn promise(&mut self, node: NodeId, bal: Ballot, accepted: Vec<(Slot, Ballot, Bytes)>) {
-        self.send(Command::Promise(
-            node,
-            bal,
-            accepted.into_iter().map(|(slot, bal, val)| SlotValueTuple(slot, bal, val)).collect(),
-        ));
-    }
-
-    fn accept(&mut self, bal: Ballot, values: Vec<(Slot, Bytes)>) {
-        self.send(Command::Accept(bal, values));
-    }
-
-    fn reject(&mut self, node: NodeId, proposed: Ballot, preempted: Ballot) {
-        self.send(Command::Reject(node, proposed, preempted));
-    }
-
-    fn accepted(&mut self, node: NodeId, bal: Ballot, slots: Vec<Slot>) {
-        self.send(Command::Accepted(node, bal, slots));
-    }
-
-    fn resolution(&mut self, bal: Ballot, values: Vec<(Slot, Bytes)>) {
-        self.send(Command::Resolution(bal, values));
-    }
-
-    fn catchup(&mut self, node: NodeId, slots: Vec<Slot>) {
-        self.send(Command::Catchup(node, slots));
-    }
+pub fn invoke<C: Receiver>(replica: &mut C, command: Bytes) {
+    let cmd = match deserialize(&command) {
+        Ok(cmd) => cmd,
+        Err(_) => return,
+    };
+    replica.receive(cmd);
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,22 +1,23 @@
 use crate::{Ballot, NodeId, NodeMetadata, Slot};
 use bytes::Bytes;
-
-#[cfg(test)]
-use std::iter::Extend;
+use serde::{Deserialize, Serialize};
 
 /// Sends commands to other replicas in addition to applying
 /// resolved commands at the current replica
 pub trait Transport {
-    /// Commander type used to send messages to other instances
-    type Commander: Commander;
-
     /// Send a message to a single node
-    fn send_to<F>(&mut self, node: NodeId, node_metadata: &NodeMetadata, command: F)
-    where
-        F: FnOnce(&mut Self::Commander) -> ();
+    fn send(&mut self, node: NodeId, node_metadata: &NodeMetadata, command: Command);
 }
 
 /// Receiver of Paxos commands.
+pub trait Receiver {
+    /// Receives a command and reacts accordingly
+    fn receive(&mut self, command: Command);
+}
+
+/// Receiver of Paxos commands.
+///
+/// This is a convenience trait that breaks out reactors for each command.
 pub trait Commander {
     /// Receive a proposal
     fn proposal(&mut self, val: Bytes);
@@ -55,56 +56,73 @@ pub trait Commander {
     fn catchup(&mut self, node: NodeId, slots: Vec<Slot>);
 }
 
-// TODO: is it possible to avoid sending Bytes back to replicas that know of the
-// value?
-
-#[derive(PartialEq, Eq, Debug)]
-#[cfg(test)]
-pub enum Command {
-    Proposal(Bytes),
-    Prepare(Ballot),
-    Promise(NodeId, Ballot, Vec<(Slot, Ballot, Bytes)>),
-    Accept(Ballot, Vec<(Slot, Bytes)>),
-    Reject(NodeId, Ballot, Ballot),
-    Accepted(NodeId, Ballot, Vec<Slot>),
-    Resolution(Ballot, Vec<(Slot, Bytes)>),
-    Catchup(NodeId, Vec<Slot>),
+impl<T: Commander> Receiver for T {
+    fn receive(&mut self, command: Command) {
+        match command {
+            Command::Proposal(val) => {
+                self.proposal(val);
+            }
+            Command::Prepare(bal) => {
+                self.prepare(bal);
+            }
+            Command::Promise(node, bal, accepted) => {
+                self.promise(node, bal, accepted);
+            }
+            Command::Accept(bal, slot_vals) => {
+                self.accept(bal, slot_vals);
+            }
+            Command::Reject(node, proposed, preempted) => {
+                self.reject(node, proposed, preempted);
+            }
+            Command::Accepted(node, bal, slots) => {
+                self.accepted(node, bal, slots);
+            }
+            Command::Resolution(bal, slot_vals) => {
+                self.resolution(bal, slot_vals);
+            }
+            Command::Catchup(node, slots) => {
+                self.catchup(node, slots);
+            }
+        }
+    }
 }
 
-#[cfg(test)]
-impl<T> Commander for T
-where
-    T: Extend<Command>,
-{
-    fn proposal(&mut self, bytes: Bytes) {
-        self.extend(Some(Command::Proposal(bytes)));
-    }
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+/// RPC commands sent between replicas
+pub enum Command {
+    /// Propose a value
+    Proposal(Bytes),
 
-    fn prepare(&mut self, bal: Ballot) {
-        self.extend(Some(Command::Prepare(bal)));
-    }
+    /// Phase 1a PREPARE message containing the proposed ballot
+    Prepare(Ballot),
 
-    fn promise(&mut self, node: NodeId, bal: Ballot, accepted: Vec<(Slot, Ballot, Bytes)>) {
-        self.extend(Some(Command::Promise(node, bal, accepted)));
-    }
+    /// Phase 1b PROMISE message containing the node
+    /// that generated the promise, the ballot promised and all accepted
+    /// values within the open window.
+    Promise(NodeId, Ballot, Vec<(Slot, Ballot, Bytes)>),
 
-    fn accept(&mut self, bal: Ballot, values: Vec<(Slot, Bytes)>) {
-        self.extend(Some(Command::Accept(bal, values)));
-    }
+    /// Phase 2a ACCEPT message that contains the the slot, proposed
+    /// ballot and value of the proposal. The ballot contains the node of
+    /// the leader of the slot.
+    Accept(Ballot, Vec<(Slot, Bytes)>),
 
-    fn reject(&mut self, node: NodeId, proposed: Ballot, promised: Ballot) {
-        self.extend(Some(Command::Reject(node, proposed, promised)));
-    }
+    /// REJECT a peer's previous message containing a higher ballot that
+    /// preempts either a Phase 1a (PREPARE) for Phase 2a (ACCEPT) message.
+    Reject(NodeId, Ballot, Ballot),
 
-    fn accepted(&mut self, node: NodeId, bal: Ballot, slots: Vec<Slot>) {
-        self.extend(Some(Command::Accepted(node, bal, slots)));
-    }
+    /// Phase 2b ACCEPTED message containing the acceptor that has
+    /// accepted the slot's proposal along with the ballot that generated
+    /// the slot.
+    Accepted(NodeId, Ballot, Vec<Slot>),
 
-    fn resolution(&mut self, bal: Ballot, values: Vec<(Slot, Bytes)>) {
-        self.extend(Some(Command::Resolution(bal, values)));
-    }
+    /// Resolution of a slot that has been accepted by a
+    /// majority of acceptors.
+    ///
+    /// NOTE: Resolutions may arrive out-of-order. No guarantees are made on
+    /// slot order.
+    Resolution(Ballot, Vec<(Slot, Bytes)>),
 
-    fn catchup(&mut self, node: NodeId, slots: Vec<Slot>) {
-        self.extend(Some(Command::Catchup(node, slots)));
-    }
+    /// Request sent to a distinguished learner to catch up to latest slot
+    /// values.
+    Catchup(NodeId, Vec<Slot>),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 //! # }
 //! ```
 extern crate bytes;
+extern crate serde;
 #[macro_use]
 extern crate log;
 #[cfg(test)]
@@ -31,7 +32,7 @@ extern crate lazy_static;
 extern crate test;
 
 mod acceptor;
-mod commands;
+pub mod commands;
 mod config;
 pub mod liveness;
 mod node;
@@ -41,9 +42,10 @@ mod window;
 
 use std::cmp;
 
-pub use commands::{Commander, Transport};
+pub use commands::{Command, Receiver, Transport};
 pub use config::{Configuration, NodeMetadata};
 pub use node::Node;
+use serde::{Deserialize, Serialize};
 pub use statemachine::ReplicatedState;
 use std::marker::Sized;
 pub use window::DecisionSet;
@@ -58,7 +60,7 @@ pub type NodeId = u32;
 /// Ballot numbering is an increasing number in order to order proposals
 /// across multiple nodes. Ballots are unique in that ballot numbers between
 /// nodes are unique and it is algorithmically increasing per node.
-#[derive(PartialEq, Hash, Eq, Clone, Copy, Debug)]
+#[derive(PartialEq, Hash, Eq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Ballot(pub u32, pub NodeId);
 
 impl Ballot {
@@ -87,7 +89,7 @@ impl Ord for Ballot {
     }
 }
 
-pub trait Replica: Commander {
+pub trait Replica: Receiver {
     /// Proposes that the current node take over leadership
     fn propose_leadership(&mut self);
 


### PR DESCRIPTION
This change simplifies the interface to Replica and some of the additional implementations of the Replica interface. In addition, the Command enum is now public and Serializable/Deserializable with Serde.